### PR TITLE
test(ci): add macOS E2E and Secure Enclave probe

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,31 @@ jobs:
       - name: Run flake checks
         run: cd dev && nix flake check -L
 
+  e2e:
+    name: Run packaged macOS E2E
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix
+      - name: Run packaged macOS E2E
+        run: ./tests/e2e.nu .
+
+  secure-enclave-e2e:
+    name: Try Secure Enclave E2E
+    runs-on: macos-latest
+    continue-on-error: true
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix
+      - name: Try Secure Enclave E2E
+        run: ./tests/e2e-secure-enclave.nu .
+
   build:
     name: Build package
     needs: [format, whitespace, test, flake-check]

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -32,6 +32,9 @@
 
       perSystem =
         { config, pkgs, ... }:
+        let
+          package = inputs.root.packages.${pkgs.system}.default;
+        in
         {
           treefmt = {
             projectRoot = ./..;
@@ -65,6 +68,16 @@
               }
               ''
                 ${pkgs.nushell}/bin/nu --no-config-file ${./../tests/check.nu} ${./..}
+                touch "$out"
+              '';
+
+          checks.packaged-e2e =
+            pkgs.runCommand "nix-secure-enclave-key-packaged-e2e"
+              {
+                nativeBuildInputs = [ pkgs.nushell ];
+              }
+              ''
+                ${pkgs.nushell}/bin/nu ${./../tests/e2e.nu} ${./..} --package ${package}/bin/nix-secure-enclave-key
                 touch "$out"
               '';
 

--- a/tests/check.nu
+++ b/tests/check.nu
@@ -135,6 +135,7 @@ def main [root: string] {
     } | ignore
     require ($dev_flake | str contains "programs =") "Development flake is missing formatter programs"
     require ($dev_flake | str contains "typos") "Development flake is missing typos"
+    require ($dev_flake | str contains "checks.packaged-e2e") "Development flake is missing the packaged E2E check"
 
     [
         "versionFile = -"

--- a/tests/check.nu
+++ b/tests/check.nu
@@ -39,13 +39,20 @@ def main [root: string] {
         "modules/darwin-module.nix"
         "modules/home-manager-module.nix"
         "tests/fixtures-public-key.pub"
+        "tests/e2e.nu"
+        "tests/e2e-secure-enclave.nu"
+        ".github/workflows/ci.yaml"
     ]
     require-files $root $required
 
     let cli_path = $root | path join "src/nix-secure-enclave-key.nu"
     let signer_path = $root | path join "src/nix-secure-enclave-key-git-sign.nu"
+    let e2e_path = $root | path join "tests/e2e.nu"
+    let secure_e2e_path = $root | path join "tests/e2e-secure-enclave.nu"
     check-nu-source $cli_path
     check-nu-source $signer_path
+    check-nu-source $e2e_path
+    check-nu-source $secure_e2e_path
 
     let cli = (source-file $root "src/nix-secure-enclave-key.nu")
     let signer = (source-file $root "src/nix-secure-enclave-key-git-sign.nu")
@@ -53,6 +60,7 @@ def main [root: string] {
     let dev_flake = (source-file $root "dev/flake.nix")
     let tagpr = (source-file $root ".tagpr")
     let release_workflow = (source-file $root ".github/workflows/release.yaml")
+    let ci_workflow = (source-file $root ".github/workflows/ci.yaml")
     let package = (source-file $root "package.nix")
     let options_module = (source-file $root "modules/options.nix")
     let darwin_module = (source-file $root "modules/darwin-module.nix")
@@ -138,6 +146,8 @@ def main [root: string] {
     } | ignore
     require ($release_workflow | str contains "Songmu/tagpr") "Release workflow is missing tagpr"
     require ($release_workflow | str contains "nix run nixpkgs#bun -- x changelogithub") "Release workflow is missing changelogithub"
+    require ($ci_workflow | str contains "tests/e2e.nu") "CI workflow is missing packaged macOS E2E"
+    require ($ci_workflow | str contains "tests/e2e-secure-enclave.nu") "CI workflow is missing Secure Enclave E2E probe"
 
     let fixture = $root | path join "tests/fixtures-public-key"
     let prompt_result = (

--- a/tests/e2e-secure-enclave.nu
+++ b/tests/e2e-secure-enclave.nu
@@ -1,0 +1,71 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from . nixpkgs#nushell --command nu
+
+def require [condition: bool, message: string] {
+    if not $condition {
+        error make {msg: $message}
+    }
+}
+
+def run-package [root: string, arguments: list<string>]: nothing -> record {
+    let result = (do {
+        cd $root
+        ^nix run ".#default" "--" ...$arguments
+    } | complete)
+    if $result.exit_code != 0 {
+        error make {msg: $"nix run failed: ($result.stderr)"}
+    }
+    $result
+}
+
+def build-package [root: string]: nothing -> string {
+    let result = (do {
+        cd $root
+        ^nix build ".#default" "--no-link" "--print-build-logs" "--print-out-paths"
+    } | complete)
+    if $result.exit_code != 0 {
+        error make {msg: $"nix build failed: ($result.stderr)"}
+    }
+
+    let output_path = $result.stdout | lines | last | str trim
+    if ($output_path | is-empty) {
+        error make {msg: "nix build returned no package path"}
+    }
+    $output_path
+}
+
+def main [root: string] {
+    let runner_temp = $env.RUNNER_TEMP? | default (mktemp -d)
+    let run_id = $env.GITHUB_RUN_ID? | default "local"
+    let run_attempt = $env.GITHUB_RUN_ATTEMPT? | default "1"
+    let key_file = $runner_temp | path join "nix-secure-enclave-key-e2e"
+    let label = $"nix-secure-enclave-key-ci-($run_id)-($run_attempt)"
+
+    let setup_result = (run-package $root [
+        "setup"
+        "--key-file"
+        $key_file
+        "--label"
+        $label
+        "--protection"
+        "none"
+    ])
+    print $setup_result.stdout
+    require ($key_file | path exists) "Secure Enclave E2E did not create an SSH stub"
+    require ($"($key_file).pub" | path exists) "Secure Enclave E2E did not create a public key"
+
+    let package_path = build-package $root
+    let signer = $package_path | path join "bin/nix-secure-enclave-key-git-sign"
+    let input_file = $runner_temp | path join "nix-secure-enclave-key-e2e-input"
+    "Secure Enclave signing E2E" | save $input_file
+
+    let sign_result = (with-env {SSH_SK_PROVIDER: "/usr/lib/ssh-keychain.dylib"} {
+        ^$signer "-Y" "sign" "-n" "git" "-f" $key_file $input_file
+    } | complete)
+    if $sign_result.exit_code != 0 {
+        error make {msg: $"Secure Enclave SSH signing failed: ($sign_result.stderr)"}
+    }
+    require ($"($input_file).sig" | path exists) "Secure Enclave E2E did not create an SSH signature"
+
+    print "Secure Enclave E2E passed"
+}

--- a/tests/e2e.nu
+++ b/tests/e2e.nu
@@ -1,0 +1,53 @@
+#!/usr/bin/env nix
+#! nix shell --inputs-from . nixpkgs#nushell --command nu
+
+def require [condition: bool, message: string] {
+    if not $condition {
+        error make {msg: $message}
+    }
+}
+
+def run-package [root: string, arguments: list<string>]: nothing -> record {
+    let result = (do {
+        cd $root
+        ^nix run ".#default" "--" ...$arguments
+    } | complete)
+    if $result.exit_code != 0 {
+        error make {msg: $"nix run failed: ($result.stderr)"}
+    }
+    $result
+}
+
+def main [root: string] {
+    let fixture = $root | path join "tests/fixtures-public-key"
+    let expected_public_key = open --raw $"($fixture).pub" | str trim
+
+    let public_result = (run-package $root [
+        "pub"
+        "--key-file"
+        $fixture
+    ])
+    require ($public_result.stdout | str contains $expected_public_key) "Packaged pub command did not print the fixture public key"
+
+    let prompt_result = (run-package $root [
+        "github"
+        "add"
+        "--type"
+        "both"
+        "--prompt-only"
+        "--key-file"
+        $fixture
+    ])
+    require ($prompt_result.stdout | str contains "gh ssh-key add") "Packaged GitHub prompt is missing the registration command"
+    require ($prompt_result.stdout | str contains "--type signing") "Packaged GitHub prompt is missing signing registration"
+    require ($prompt_result.stdout | str contains "--type authentication") "Packaged GitHub prompt is missing authentication registration"
+
+    let doctor_result = (run-package $root [
+        "doctor"
+        "--key-file"
+        $fixture
+    ])
+    require ($doctor_result.stdout | str contains "SecurityKeyProvider") "Packaged doctor command did not inspect the SSH provider"
+
+    print "Packaged macOS E2E smoke tests passed"
+}

--- a/tests/e2e.nu
+++ b/tests/e2e.nu
@@ -7,29 +7,33 @@ def require [condition: bool, message: string] {
     }
 }
 
-def run-package [root: string, arguments: list<string>]: nothing -> record {
-    let result = (do {
-        cd $root
-        ^nix run ".#default" "--" ...$arguments
-    } | complete)
+def run-package [root: string, package: string, arguments: list<string>]: nothing -> record {
+    let result = (if ($package | is-empty) {
+        do {
+            cd $root
+            ^nix run ".#default" "--" ...$arguments
+        } | complete
+    } else {
+        ^$package ...$arguments | complete
+    })
     if $result.exit_code != 0 {
         error make {msg: $"nix run failed: ($result.stderr)"}
     }
     $result
 }
 
-def main [root: string] {
+def main [root: string, --package: string = ""] {
     let fixture = $root | path join "tests/fixtures-public-key"
     let expected_public_key = open --raw $"($fixture).pub" | str trim
 
-    let public_result = (run-package $root [
+    let public_result = (run-package $root $package [
         "pub"
         "--key-file"
         $fixture
     ])
     require ($public_result.stdout | str contains $expected_public_key) "Packaged pub command did not print the fixture public key"
 
-    let prompt_result = (run-package $root [
+    let prompt_result = (run-package $root $package [
         "github"
         "add"
         "--type"
@@ -42,7 +46,7 @@ def main [root: string] {
     require ($prompt_result.stdout | str contains "--type signing") "Packaged GitHub prompt is missing signing registration"
     require ($prompt_result.stdout | str contains "--type authentication") "Packaged GitHub prompt is missing authentication registration"
 
-    let doctor_result = (run-package $root [
+    let doctor_result = (run-package $root $package [
         "doctor"
         "--key-file"
         $fixture


### PR DESCRIPTION
## Summary

- Run packaged CLI smoke tests on a macOS GitHub Actions runner.
- Try the real Secure Enclave identity, SSH stub, and SSH signing flow with non-biometric protection.
- Keep the hosted-runner hardware probe non-blocking because Secure Enclave availability is not guaranteed in a hosted VM.

## Testing

- `./tests/check.nu .`
- `./tests/e2e.nu .`
- `gh-nix nix fmt -- --fail-on-change`
- `gh-nix nix flake check ./dev -L`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end smoke tests for packaged CLI commands, including public-key, GitHub prompt-only, and diagnostic flows.
  * Added Secure Enclave signing coverage, including key generation, package execution, and signature validation.
* **CI**
  * Added macOS automated testing for packaged builds and Secure Enclave workflows.
  * Added validation to ensure required end-to-end tests and workflow references remain present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->