### PR TITLE
feat(github): add machine-specific Secure Enclave key titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ private key.
 
 Use `--prompt-only` to print those commands without contacting GitHub.
 
+When `--title` is omitted, the CLI generates a machine-specific title from the
+identity prefix, macOS `LocalHostName`, and the first part of the public-key
+fingerprint. The default identity is titled like
+`nix-secure-enclave-key-macbook-pro-j1lHgxmxJT5g`; a named Nix identity such as
+`git-signing` is titled like
+`git-signing-macbook-pro-j1lHgxmxJT5g-nix-secure-enclave-key`. This keeps shared
+dotfiles readable when multiple Macs register different keys. Set `--title` or
+`github.title` when a fixed title is required.
+
 ## With nix-darwin
 
 The nix-darwin module is the primary integration and does not require Home
@@ -248,7 +257,7 @@ Set `system.primaryUser`, then configure the module in the system configuration:
         github = {
           autoAdd = false; # Set true to register the public key during activation.
           type = "both"; # Register SSH authentication, Git signing, or both.
-          title = "nix-secure-enclave-key"; # GitHub title for new registrations.
+          # title defaults to a machine- and public-key-specific value; set it to override that title.
         };
       };
     })
@@ -267,9 +276,11 @@ optionally, both GitHub registrations without Home Manager.
 <summary>Configure multiple identities declaratively</summary>
 
 Use a named attribute set when Git signing and SSH login should use different
-Secure Enclave identities. Attribute names are arbitrary. If `label` or
-`github.title` is omitted, the module derives it as
-`<attribute-name>-nix-secure-enclave-key`.
+Secure Enclave identities. Attribute names are arbitrary. If `label` is
+omitted, the module derives it as `<attribute-name>-nix-secure-enclave-key`.
+When `github.title` is omitted, the module passes the attribute name to the
+CLI so the generated GitHub title also includes the Mac name and public-key
+fingerprint.
 
 ```nix
 {
@@ -281,6 +292,7 @@ Secure Enclave identities. Attribute names are arbitrary. If `label` or
         protection = "none"; # Allow unattended signing without Touch ID.
         # label defaults to "git-signing-nix-secure-enclave-key".
         github.autoAdd = true; # Register this identity with GitHub during activation.
+        # github.title defaults to a machine- and public-key-specific value.
       };
       remote-server-x-ssh-login-key = {
         keyFile = "~/.ssh/id_remote_server_x"; # Non-secret stub used for this SSH host.
@@ -331,7 +343,7 @@ Home Manager is optional. Import its module and use the same
     github = {
       autoAdd = false; # Register the public key during activation; disabled by default because this writes to GitHub.
       type = "both"; # Register the key for SSH authentication, Git signing, or both.
-      title = "nix-secure-enclave-key"; # Title used for a new GitHub SSH key.
+      # title defaults to a machine- and public-key-specific value; set it to override that title.
     };
   };
 }
@@ -372,7 +384,8 @@ The options below apply to the commands shown above:
 | `--protection` | `none`: no biometric protection; `bio`: biometric protection, which may require Touch ID | `none` | `setup`, `identity ensure`, `ssh ensure` |
 | `--copy` | Flag; no value | Off | `pub` |
 | `--type` | `signing`, `authentication`, or `both` | `both` | `github add` |
-| `--title` | Any GitHub SSH key title | `nix-secure-enclave-key` | `github add` |
+| `--title` | Any GitHub SSH key title | Generated from the identity prefix, machine name, and public-key fingerprint | `github add` |
+| `--title-prefix` | Any title prefix; normally an identity attribute name | `nix-secure-enclave-key` | `github add` |
 | `--prompt-only` | Flag; no GitHub API or write is performed | Off | `github add` |
 
 `none` is the non-biometric mode. `bio` requests biometric protection for the
@@ -380,6 +393,8 @@ Secure Enclave identity and may require Touch ID when the identity is created or
 the key is used. `--type` selects GitHub's signing-key
 endpoint, authentication-key endpoint, or both. Existing GitHub keys are
 matched by algorithm and key body, not by title.
+When `--title` is omitted, `--title-prefix` controls the identity portion of
+the generated machine-specific title.
 
 The CTK commands use positional arguments: `ctk csr` takes an identity hash
 from `identity list` and the output-file path for the CSR; `ctk

--- a/modules/darwin-module.nix
+++ b/modules/darwin-module.nix
@@ -32,15 +32,11 @@ let
     name: identity:
     let
       label = if identity.label == null then "${name}-nix-secure-enclave-key" else identity.label;
-      github-title =
-        if identity.github.title == null then "${name}-nix-secure-enclave-key" else identity.github.title;
+      title-prefix = if cfg.identities == { } then "nix-secure-enclave-key" else name;
     in
     identity
     // {
-      inherit name label;
-      github = identity.github // {
-        title = github-title;
-      };
+      inherit name label title-prefix;
       resolvedKeyFile = resolve-key-file identity.keyFile;
     }
   ) configured-identities;
@@ -63,13 +59,20 @@ let
   ) identities;
   github-add-commands = lib.concatMapStringsSep "\n" (
     identity:
+    let
+      github-title-argument =
+        if identity.github.title == null then
+          "--title-prefix ${lib.escapeShellArg identity.title-prefix}"
+        else
+          "--title ${lib.escapeShellArg identity.github.title}";
+    in
     lib.optionalString identity.github.autoAdd ''
       ${run-as-primary-user "/usr/bin/env"} \
         ${lib.escapeShellArg "PATH=${pkgs.gh}/bin:/usr/bin:/bin:/usr/sbin:/sbin"} \
         ${package}/bin/nix-secure-enclave-key github add \
           --key-file ${lib.escapeShellArg identity.resolvedKeyFile} \
           --type ${lib.escapeShellArg identity.github.type} \
-          --title ${lib.escapeShellArg identity.github.title}
+          ${github-title-argument}
     ''
   ) identities;
   ssh-identity-files = lib.concatMapStringsSep "\n" (

--- a/modules/home-manager-module.nix
+++ b/modules/home-manager-module.nix
@@ -31,15 +31,11 @@ let
     name: identity:
     let
       label = if identity.label == null then "${name}-nix-secure-enclave-key" else identity.label;
-      github-title =
-        if identity.github.title == null then "${name}-nix-secure-enclave-key" else identity.github.title;
+      title-prefix = if cfg.identities == { } then "nix-secure-enclave-key" else name;
     in
     identity
     // {
-      inherit name label;
-      github = identity.github // {
-        title = github-title;
-      };
+      inherit name label title-prefix;
       resolvedKeyFile = resolve-key-file identity.keyFile;
     }
   ) configured-identities;
@@ -60,11 +56,18 @@ let
   ) identities;
   github-add-commands = lib.concatMapStringsSep "\n" (
     identity:
+    let
+      github-title-argument =
+        if identity.github.title == null then
+          "--title-prefix ${lib.escapeShellArg identity.title-prefix}"
+        else
+          "--title ${lib.escapeShellArg identity.github.title}";
+    in
     lib.optionalString identity.github.autoAdd ''
       ${package}/bin/nix-secure-enclave-key github add \
         --key-file ${lib.escapeShellArg identity.resolvedKeyFile} \
         --type ${lib.escapeShellArg identity.github.type} \
-        --title ${lib.escapeShellArg identity.github.title}
+        ${github-title-argument}
     ''
   ) identities;
   github-activation-dependencies =

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -74,7 +74,7 @@
             github.title = lib.mkOption {
               type = lib.types.nullOr lib.types.str;
               default = null;
-              description = "GitHub title for this identity when it is registered. When omitted, it is derived as <name>-nix-secure-enclave-key.";
+              description = "GitHub title for this identity when it is registered. When omitted, it is generated from the identity name, macOS machine name, and public-key fingerprint.";
             };
           };
         }
@@ -118,9 +118,9 @@
     };
 
     github.title = lib.mkOption {
-      type = lib.types.str;
-      default = "nix-secure-enclave-key";
-      description = "Title to use when registering the public key with GitHub.";
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "GitHub title for the default identity. When omitted, it is generated from the macOS machine name and public-key fingerprint.";
     };
   };
 }

--- a/src/nix-secure-enclave-key.nu
+++ b/src/nix-secure-enclave-key.nu
@@ -9,6 +9,8 @@ const ssh_add_path = "/usr/bin/ssh-add"
 const ssh_agent_path = "/usr/bin/ssh-agent"
 const ssh_keygen_path = "/usr/bin/ssh-keygen"
 const pbcopy_path = "/usr/bin/pbcopy"
+const scutil_path = "/usr/sbin/scutil"
+const hostname_path = "/bin/hostname"
 
 def is-macos []: nothing -> bool {
     $nu.os-info.name == "macos"
@@ -181,6 +183,75 @@ def public-key-fingerprint-for-line [public_key: string]: nothing -> string {
         error make {msg: "could not read the public key fingerprint from ssh-agent"}
     }
     $fields.1
+}
+
+def normalize-title-component [value: string]: nothing -> string {
+    $value
+    | str trim
+    | str replace --all " " "-"
+    | str replace --all "/" "-"
+    | str replace --all ":" "-"
+    | str replace --all "+" "-"
+    | str replace --all "=" ""
+}
+
+def local-machine-name []: nothing -> string {
+    let scutil_name = if ($scutil_path | path exists) {
+        let result = (^$scutil_path "--get" "LocalHostName" | complete)
+        if $result.exit_code == 0 {
+            $result.stdout | str trim
+        } else {
+            ""
+        }
+    } else {
+        ""
+    }
+    let hostname = if ($hostname_path | path exists) {
+        let result = (^$hostname_path | complete)
+        if $result.exit_code == 0 {
+            $result.stdout | str trim
+        } else {
+            ""
+        }
+    } else {
+        ""
+    }
+    [$scutil_name $hostname "mac"]
+    | each {|value| normalize-title-component $value }
+    | where {|value| not ($value | is-empty)}
+    | first
+}
+
+def short-public-key-fingerprint [public_file: string]: nothing -> string {
+    let short = (
+        public-key-fingerprint $public_file
+        | str replace "SHA256:" ""
+        | split chars
+        | first 12
+        | str join ""
+    )
+    normalize-title-component $short
+}
+
+def default-github-title [public_file: string, title_prefix: string]: nothing -> string {
+    let prefix = if ($title_prefix | str trim | is-empty) {
+        $default_label
+    } else {
+        normalize-title-component $title_prefix
+    }
+    let components = [
+        $prefix
+        (local-machine-name)
+        (short-public-key-fingerprint $public_file)
+    ]
+    let components = if ($prefix | str ends-with $default_label) {
+        $components
+    } else {
+        $components ++ [$default_label]
+    }
+    $components
+    | where {|value| not ($value | is-empty)}
+    | str join "-"
 }
 
 def select-generated-pair [pairs: list<record>, identity_hash: string]: nothing -> record {
@@ -643,7 +714,8 @@ def require-github-type [key_type: string] {
 # Register the public key with GitHub without exposing the Secure Enclave secret.
 def "main github add" [
     --type: string = "both" # GitHub key kind: `signing`, `authentication`, or `both`.
-    --title: string = "nix-secure-enclave-key" # Title to use for a newly registered GitHub key.
+    --title: string = "" # Explicit title for a newly registered GitHub key; an identity-specific title is generated when omitted.
+    --title-prefix: string = "nix-secure-enclave-key" # Prefix for the generated title, usually the identity attribute name.
     --key-file: string = "~/.ssh/id_enclave_key" # Path to the SSH stub/reference whose matching `.pub` file should be registered.
     --prompt-only # Print `gh ssh-key add` commands without contacting GitHub or writing a key.
 ] {
@@ -651,6 +723,11 @@ def "main github add" [
     require-github-type $type
     let public_state = (key-state $key_file)
     let public_key = (read-public-key $key_file)
+    let resolved_title = if ($title | str trim | is-empty) {
+        default-github-title $public_state.public_file $title_prefix
+    } else {
+        $title
+    }
     let key_types = if $type == "both" {
         ["signing", "authentication"]
     } else {
@@ -659,10 +736,10 @@ def "main github add" [
 
     $key_types | each {|key_type|
         if $prompt_only {
-            registration-prompt $public_state.public_file $key_type $title
+            registration-prompt $public_state.public_file $key_type $resolved_title
             "prompted"
         } else {
-            register-github-key $public_state.public_file $public_key $key_type $title
+            register-github-key $public_state.public_file $public_key $key_type $resolved_title
         }
     } | ignore
 }

--- a/tests/check.nu
+++ b/tests/check.nu
@@ -75,6 +75,9 @@ def main [root: string] {
         "SecurityKeyProvider"
         "identity-hash-for-label"
         "public-key-fingerprint"
+        "default-github-title"
+        "title-prefix"
+        "scutil"
         "select-generated-pair"
         "public-key-reference-for-identity"
         "ssh-add"
@@ -126,6 +129,7 @@ def main [root: string] {
         "github.autoAdd"
         "github.type"
         "github.title"
+        "title-prefix"
         "home.activation.nix-secure-enclave-key-github-add"
         "pkgs.gh"
         "default = false"
@@ -174,6 +178,35 @@ def main [root: string] {
     require ($prompt_result.stdout | str contains "gh ssh-key add") "GitHub prompt is missing the registration command"
     require ($prompt_result.stdout | str contains "--type signing") "GitHub signing prompt is missing"
     require ($prompt_result.stdout | str contains "--type authentication") "GitHub authentication prompt is missing"
+    let generated_title_line = (
+        $prompt_result.stdout
+        | lines
+        | where {|line| $line | str contains "--title "}
+        | first
+    )
+    require ($generated_title_line | str contains "nix-secure-enclave-key") "GitHub prompt is missing the generated title"
+    require (
+        not ($generated_title_line | str contains "--title 'nix-secure-enclave-key'")
+    ) "GitHub prompt still uses the static default title"
+
+    let explicit_title_result = (
+        ^nu --no-config-file $cli_path github add --type signing --prompt-only --title "custom-title" --key-file $fixture
+        | complete
+    )
+    if $explicit_title_result.exit_code != 0 {
+        error make {msg: $"GitHub explicit-title check failed: ($explicit_title_result.stderr)"}
+    }
+    require ($explicit_title_result.stdout | str contains "--title 'custom-title'") "GitHub prompt does not preserve an explicit title"
+
+    let prefixed_title_result = (
+        ^nu --no-config-file $cli_path github add --type signing --prompt-only --title-prefix "git-signing" --key-file $fixture
+        | complete
+    )
+    if $prefixed_title_result.exit_code != 0 {
+        error make {msg: $"GitHub title-prefix check failed: ($prefixed_title_result.stderr)"}
+    }
+    require ($prefixed_title_result.stdout | str contains "git-signing-") "GitHub prompt does not include the title prefix"
+    require ($prefixed_title_result.stdout | str contains "-nix-secure-enclave-key'") "GitHub prompt does not include the package title suffix"
 
     print "nix-secure-enclave-key static checks passed"
 }

--- a/tests/fixtures-public-key.pub
+++ b/tests/fixtures-public-key.pub
@@ -1,1 +1,1 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC7fD5x3q4vZ7r6KQhT4b4jD6G2J8pY3qW9sL1mN0oP nix-secure-enclave-key-test
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINO3Q/S+Rdt+ETNOs0BgQ5V1QH3l9CFcxpnZPvTQ4pj5 nix-secure-enclave-key-test


### PR DESCRIPTION
## Summary

- generate default GitHub SSH key titles from the identity prefix, macOS `LocalHostName`, and a short public-key fingerprint
- preserve explicit `--title` and `github.title` overrides for both nix-darwin and Home Manager
- document the shared-dotfiles behaviour and cover generated, prefixed, and explicit title prompts

This keeps registration idempotent by public-key content while making different Macs easy to distinguish in GitHub. No private key material is read or exported.

## Testing

- `nix fmt -- --fail-on-change`
- `nu tests/check.nu .`
- `nix flake check -L`
- `nix build .#default --no-link --print-build-logs`
- `git diff --check`
