### PR TITLE
fix(darwin): sign Git tags when signByDefault is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Set `system.primaryUser`, then configure the module in the system configuration:
           };
         };
         signingIdentity = "git-signing"; # Select the identity used by Git SSH signing.
-        signByDefault = true; # Sign Git commits with the Secure Enclave-backed key.
+        signByDefault = true; # Sign Git commits and tags with the Secure Enclave-backed key.
       };
     })
   ];
@@ -330,7 +330,7 @@ fingerprint.
       };
     };
     signingIdentity = "git-signing"; # Select the identity used by Git SSH signing.
-    signByDefault = true; # Sign Git commits by default.
+    signByDefault = true; # Sign Git commits and tags by default.
   };
 }
 ```
@@ -378,7 +378,7 @@ Home Manager is optional. Import its module and use the same
       };
     };
     signingIdentity = "git-signing"; # Select the identity used by Git SSH signing.
-    signByDefault = true; # Make Git SSH signing the default for commits.
+    signByDefault = true; # Make Git SSH signing the default for commits and tags.
   };
 }
 ```

--- a/modules/darwin-module.nix
+++ b/modules/darwin-module.nix
@@ -83,6 +83,9 @@ let
       ${run-as-primary-user "/usr/bin/git"} config --global commit.gpgsign ${
         if cfg.signByDefault then "true" else "false"
       }
+      ${run-as-primary-user "/usr/bin/git"} config --global tag.gpgsign ${
+        if cfg.signByDefault then "true" else "false"
+      }
     ''}
 
     ${github-add-commands}

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -71,7 +71,7 @@
     signByDefault = lib.mkOption {
       type = lib.types.bool;
       default = true;
-      description = "Whether Git commits should be SSH-signed by default.";
+      description = "Whether Git commits and tags should be SSH-signed by default.";
     };
 
   };


### PR DESCRIPTION
## Summary

The nix-darwin module only set `commit.gpgsign`, so annotated tags were left unsigned even with `signByDefault = true`. The home-manager module already signs both, because home-manager derives `commit.gpgSign` and `tag.gpgSign` from `signing.signByDefault`.

## What Changed

- `modules/darwin-module.nix`: set `tag.gpgsign` alongside `commit.gpgsign` in the activation script, driven by the same `signByDefault` value.
- `modules/options.nix`: mention tags in the `signByDefault` option description.
- `README.md`: update the `signByDefault` comments to cover tags.

## Testing

- `nix flake check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Git tags are now signed automatically alongside Git commits when default signing is enabled.
  - Tag signing uses the same configured SSH signing settings as commit signing.

- **Documentation**
  - Updated configuration examples and option descriptions to clarify that default signing applies to both Git commits and tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->